### PR TITLE
ci: remove duplicate yamllint step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,6 @@ jobs:
       - name: Pre-commit checks
         run: uvx pre-commit run --all-files --show-diff-on-failure
 
-      - name: YAML lint
-        run: uvx yamllint -s .
-
       - name: JSON syntax validation
         run: |
           uv run python - <<'PY'


### PR DESCRIPTION
### Motivation
- Éviter l'exécution redondante de `yamllint` en CI car il est déjà exécuté via le hook `yamllint` dans ` .pre-commit-config.yaml`.

### Description
- Suppression de l'étape `YAML lint` dans `.github/workflows/ci.yml` et conservation de la configuration `yamllint` dans `.pre-commit-config.yaml` (repo `adrienverge/yamllint`, id `yamllint`).

### Testing
- Exécution de `rg -n "yamllint|Pre-commit checks|YAML lint"` pour vérifier les références (succès), tentative de `uvx pre-commit run yamllint --all-files` qui a échoué à cause d'une erreur réseau vers PyPI, et `git commit` du changement (succès).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c79616f53c832e878cec5abc1edffd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->