### PR TITLE
Configure SonarQube analysis for DEALIoT

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -40,4 +40,4 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL || 'https://sonarcloud.io' }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -33,10 +33,8 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          uv run python -m unittest discover -s tests -p 'test_*.py'
-          uv run python -m pip install coverage
-          uv run coverage run -m unittest discover -s tests -p 'test_*.py'
-          uv run coverage xml -o coverage.xml
+          uv run --with coverage coverage run -m unittest discover -s tests -p 'test_*.py'
+          uv run --with coverage coverage xml -o coverage.xml
 
       - name: SonarQube scan
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -29,7 +29,7 @@ jobs:
           cache: pip
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
 
       - name: Generate coverage report
         run: |

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,45 @@
+name: SonarQube
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sonarqube:
+    name: SonarQube Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Generate coverage report
+        run: |
+          uv run python -m unittest discover -s tests -p 'test_*.py'
+          uv run python -m pip install coverage
+          uv run coverage run -m unittest discover -s tests -p 'test_*.py'
+          uv run coverage xml -o coverage.xml
+
+      - name: SonarQube scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -39,7 +39,7 @@ jobs:
           uv run coverage xml -o coverage.xml
 
       - name: SonarQube scan
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ This repository is configured for GitHub Actions-based SonarQube analysis:
 - Project scanner config: `sonar-project.properties`
 - Required repository secrets:
   - `SONAR_TOKEN`
-  - `SONAR_HOST_URL` (for example `https://sonarcloud.io` or your self-hosted SonarQube URL)
+  - `SONAR_HOST_URL` (optional; defaults to `https://sonarcloud.io` when unset, set it for self-hosted SonarQube)
 
 The workflow runs on pushes to `main`/`master`, on pull requests, and manually via `workflow_dispatch`.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository implements a reproducible edge-to-cloud architecture for multimo
 [![Dependabot Updates](https://github.com/Smartappli/DEALIoT/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/Smartappli/DEALIoT/actions/workflows/dependabot/dependabot-updates)
 [![Renovate](https://github.com/Smartappli/DEALIoT/actions/workflows/renovate.yml/badge.svg)](https://github.com/Smartappli/DEALIoT/actions/workflows/renovate.yml)
 [![ShellCheck](https://github.com/Smartappli/DEALIoT/actions/workflows/shellcheck.yml/badge.svg)](https://github.com/Smartappli/DEALIoT/actions/workflows/shellcheck.yml)
+[![SonarQube](https://github.com/Smartappli/DEALIoT/actions/workflows/sonarqube.yml/badge.svg)](https://github.com/Smartappli/DEALIoT/actions/workflows/sonarqube.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Smartappli_DEALIoT&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Smartappli_DEALIoT)
 
 
@@ -182,6 +183,18 @@ This makes the Airflow workflow operational instead of only printing objects to 
 - `orchestration_net`: Airflow, Grafana, Apicurio UI, and other control-plane services.
 
 This segmentation limits accidental coupling between components and makes troubleshooting easier.
+
+## SonarQube setup
+
+This repository is configured for GitHub Actions-based SonarQube analysis:
+
+- Workflow: `.github/workflows/sonarqube.yml`
+- Project scanner config: `sonar-project.properties`
+- Required repository secrets:
+  - `SONAR_TOKEN`
+  - `SONAR_HOST_URL` (for example `https://sonarcloud.io` or your self-hosted SonarQube URL)
+
+The workflow runs on pushes to `main`/`master`, on pull requests, and manually via `workflow_dispatch`.
 
 ## 7. Configuration model
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,5 @@
 sonar.projectKey=Smartappli_DEALIoT
+sonar.organization=smartappli-github
 sonar.projectName=DEALIoT
 sonar.projectVersion=1.0
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=Smartappli_DEALIoT
+sonar.projectName=DEALIoT
+sonar.projectVersion=1.0
+
+sonar.sources=airflow,docker-compose.yml,mqtt-kafka-bridge,pipelines,flink,beam,scripts,orchestration,patroni,pgbouncer,apicurio,prometheus,grafana,haproxy,tests
+sonar.tests=tests
+
+sonar.python.version=3.12
+sonar.sourceEncoding=UTF-8
+
+sonar.exclusions=**/.venv/**,**/__pycache__/**,**/*.pyc,**/.git/**,**/logs/**,**/node_modules/**
+sonar.test.inclusions=tests/**/*.py
+
+sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
### Motivation

- Add repository-level SonarQube integration so CI can run static analysis and publish coverage results for improved code quality visibility.

### Description

- Add a GitHub Actions workflow at `./.github/workflows/sonarqube.yml` that generates a coverage report and runs the SonarQube scanner on pushes to `main`/`master`, pull requests, and manual dispatch.
- Add `sonar-project.properties` with project metadata, source and test paths, Python settings, exclusions, and coverage report path so the scanner has repository-specific configuration.
- Update `README.md` to include a SonarQube workflow badge and a `SonarQube setup` section documenting the workflow and required secrets (`SONAR_TOKEN` and `SONAR_HOST_URL`).

### Testing

- Ran `python -m unittest -v tests/unit/test_repository_unit.py` which passed.
- Ran `python -m unittest -v tests/deployment/test_deployment_readiness.py` which passed.
- Attempted to run `uv run python -m unittest` which failed due to the CI wrapper expecting a `[project]` table in `pyproject.toml` and therefore was not used for validation.
- Attempted a YAML parse check for `./.github/workflows/sonarqube.yml` which could not run because `PyYAML` was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca38885038832e87f50473501c44dd)