### PR TITLE
CI: pin astral-sh/setup-uv and add Codacy coverage upload in SonarQube workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           cache: pip
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
 
       - name: Pre-commit checks
         run: uvx pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -36,6 +36,14 @@ jobs:
           uv run --with coverage coverage run -m unittest discover -s tests -p 'test_*.py'
           uv run --with coverage coverage xml -o coverage.xml
 
+      - name: Upload coverage to Codacy
+        if: ${{ secrets.CODACY_PROJECT_TOKEN != '' || secrets.CODACY_API_TOKEN != '' }}
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          api-token: ${{ secrets.CODACY_API_TOKEN }}
+          coverage-reports: coverage.xml
+
       - name: SonarQube scan
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
         env:


### PR DESCRIPTION
### Motivation
- Pin `astral-sh/setup-uv` to a specific commit to avoid unexpected behavior from upstream tag changes and ensure reproducible runner setup.
- Add conditional upload of coverage to Codacy from the SonarQube workflow so coverage reports can be published when project tokens are available.

### Description
- In `.github/workflows/ci.yml` replaced `uses: astral-sh/setup-uv@v7` with `uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57` to pin the action to a commit.
- In `.github/workflows/sonarqube.yml` ensured `astral-sh/setup-uv` is pinned to the same commit and retained generation of a `coverage.xml` via `uv run --with coverage coverage xml -o coverage.xml`.
- Added a new conditional step `Upload coverage to Codacy` that runs when `secrets.CODACY_PROJECT_TOKEN` or `secrets.CODACY_API_TOKEN` are present and uses `codacy/codacy-coverage-reporter-action` to upload `coverage.xml`.

### Testing
- No automated tests were executed as part of this PR; the updated workflows will run `uvx pre-commit` and JSON syntax validation in CI, and the SonarQube job will run unit tests with `coverage run -m unittest discover -s tests -p 'test_*.py'` and produce `coverage.xml` when the workflows run in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca4f9ca690832e91417cd01157e8d9)