### PR TITLE
ci: configure SonarQube coverage reporting

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          uv run --with coverage coverage run -m unittest discover -s tests -p 'test_*.py'
-          uv run --with coverage coverage xml -o coverage.xml
+          uv run --with pytest --with pytest-cov \
+            pytest --cov=. --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage to Codacy
         if: ${{ secrets.CODACY_PROJECT_TOKEN != '' || secrets.CODACY_API_TOKEN != '' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,23 @@ format_js = true
 format_css = true
 ignore = "H006,H030"
 
+
+[tool.coverage.run]
+branch = true
+relative_files = true
+source = ["."]
+omit = [
+  "tests/*",
+  "**/__init__.py",
+]
+
+[tool.coverage.report]
+skip_empty = true
+show_missing = true
+
+[tool.coverage.xml]
+output = "coverage.xml"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]


### PR DESCRIPTION
### Motivation
- Ensure SonarQube (and optional Codacy) receives a stable `coverage.xml` generated directly from the repository test suite by switching to `pytest` + `pytest-cov` in the CI workflow. 
- Provide a reproducible Coverage.py configuration so report output uses relative paths, includes branch coverage, and excludes test files from measured sources.

### Description
- Update `.github/workflows/sonarqube.yml` to generate coverage with `pytest` and `pytest-cov` via `uv` using `pytest --cov=. --cov-report=xml --cov-report=term-missing` instead of the previous `coverage run -m unittest` flow. 
- Add Coverage.py configuration to `pyproject.toml` under `[tool.coverage.*]` to enable `branch = true`, `relative_files = true`, `source = ["."]`, omit `tests/*` and `**/__init__.py`, and set XML output to `coverage.xml`. 
- Keep Codacy upload step and SonarQube scan step unchanged so the produced `coverage.xml` will be uploaded/consumed by existing steps.

### Testing
- Ran `python -m pytest` locally and all tests passed (`14 passed`).
- Attempted `python -m pytest --cov=. --cov-report=xml --cov-report=term-missing` locally and it failed because the `pytest-cov` plugin is not installed in the current environment. 
- Attempted the `uv`-based command and it failed in this environment with `No 'project' table found in pyproject.toml`, but the workflow change targets CI where `uv` will be installed and provide the expected execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca5fc1621c832eaf5e792411bfd0f4)