### PR TITLE
Sort package names alphanumerically in Dockerfiles

### DIFF
--- a/flink/Dockerfile.pyflink
+++ b/flink/Dockerfile.pyflink
@@ -3,10 +3,10 @@ FROM apache/flink:2.0.0-scala_2.12-java17
 USER root
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 \
-    python3-venv \
-    python3-pip \
     build-essential \
+    python3 \
+    python3-pip \
+    python3-venv \
  && rm -rf /var/lib/apt/lists/*
 
 COPY ./flink/requirements-pyflink.txt /tmp/requirements-pyflink.txt
@@ -15,9 +15,9 @@ RUN python3 --version \
  && python3 -m venv /opt/flink/venv \
  && /opt/flink/venv/bin/python -m pip install --upgrade pip \
  && /opt/flink/venv/bin/pip install --no-cache-dir \
+      "packaging" \
       "setuptools<81" \
       "wheel<0.46" \
-      "packaging" \
  && /opt/flink/venv/bin/pip install --no-cache-dir --no-build-isolation -r /tmp/requirements-pyflink.txt \
  && /opt/flink/venv/bin/python - <<'PY'
 import sys

--- a/mqtt-kafka-bridge/Dockerfile
+++ b/mqtt-kafka-bridge/Dockerfile
@@ -3,9 +3,9 @@ FROM python:3.13-slim
 WORKDIR /app
 
 RUN pip install --no-cache-dir \
-    paho-mqtt \
     kafka-python \
-    lz4
+    lz4 \
+    paho-mqtt
 
 RUN useradd --create-home --shell /bin/bash appuser
 COPY bridge.py /app/bridge.py

--- a/orchestration/Dockerfile
+++ b/orchestration/Dockerfile
@@ -3,18 +3,18 @@ FROM apache/airflow:3.1.8
 USER airflow
 
 RUN pip install --no-cache-dir \
+    "apache-airflow-providers-amazon" \
+    "apache-airflow-providers-apache-beam[common.compat]" \
+    "apache-airflow-providers-apache-flink" \
+    "apache-airflow-providers-apache-kafka" \
+    "apache-airflow-providers-fab" \
+    "apache-airflow-providers-postgres" \
+    "apache-airflow-providers-redis" \
     "apache-airflow[statsd]==${AIRFLOW_VERSION}" \
     "apache-beam==2.72.0" \
-    "psycopg[binary]" \
-    "kafka-python" \
-    "cachetools>=6.0" \
     "boto3" \
+    "cachetools>=6.0" \
+    "kafka-python" \
+    "psycopg[binary]" \
     "requests" \
-    "apache-airflow-providers-apache-beam[common.compat]" \
-    "apache-airflow-providers-apache-kafka" \
-    "apache-airflow-providers-postgres" \
-    "apache-airflow-providers-amazon" \
-    "apache-airflow-providers-fab" \
-    "apache-airflow-providers-redis" \
-    "apache-airflow-providers-apache-flink" \
     --constraint "${HOME}/constraints.txt"


### PR DESCRIPTION
### Motivation
- Keep package lists consistent and easier to review by ordering entries alphanumerically.
- Reduce incidental churn in diffs and make future dependency changes less error-prone.

### Description
- Reordered the pip install block in `orchestration/Dockerfile` so provider and Python packages are in alphanumeric order.
- Reordered the pip install block in `mqtt-kafka-bridge/Dockerfile` to alphabetize the installed packages.
- Reordered the `apt-get install` list and the pip bootstrap package list in `flink/Dockerfile.pyflink` to be alphabetically sorted.

### Testing
- No automated tests were run because these are ordering-only changes that do not modify functionality.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cae4e4644c832ea7d3408f7414e1ea)