### PR TITLE
chore(renovate): remove package grouping rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,19 +14,5 @@
   "timezone": "Etc/UTC",
   "schedule": [
     "before 5am on Monday"
-  ],
-  "packageRules": [
-    {
-      "matchManagers": ["github-actions"],
-      "groupName": "github-actions"
-    },
-    {
-      "matchManagers": ["dockerfile", "docker-compose"],
-      "groupName": "container-images"
-    },
-    {
-      "matchManagers": ["pip_requirements", "pep621"],
-      "groupName": "python-dependencies"
-    }
   ]
 }


### PR DESCRIPTION
### Motivation
- Stop grouping dependency updates by manager so Renovate opens separate PRs instead of grouped ones.

### Description
- Remove the `packageRules` array from `renovate.json`, deleting the grouping entries for `github-actions`, container images, and python dependencies.

### Testing
- Ran `python -m json.tool renovate.json >/dev/null` to validate `renovate.json`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caeab33784832e9c92d97f75a34c3c)