### PR TITLE
Fix SonarQube workflow conditional for Codacy token

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -18,6 +18,7 @@ jobs:
       contents: read
     env:
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      PYTHONPATH: ${{ github.workspace }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          uv run --with pytest --with pytest-cov \
+          uv run --with boto3 --with pytest --with pytest-cov \
             pytest --cov=. --cov-report=xml --cov-report=term-missing
 
       - name: Verify coverage report for SonarQube

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -51,13 +53,11 @@ jobs:
           PY
 
       - name: Run codacy-coverage-reporter
-        if: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
+        if: ${{ env.CODACY_PROJECT_TOKEN != '' }}
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
         with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          project-token: ${{ env.CODACY_PROJECT_TOKEN }}
           coverage-reports: "coverage.xml"
-        env:
-          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
       - name: SonarQube scan
         uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4


### PR DESCRIPTION
### Motivation
- Fix workflow validation error caused by using `secrets.CODACY_PROJECT_TOKEN` directly in an `if:` expression, which GitHub Actions does not allow in that position.

### Description
- Expose `CODACY_PROJECT_TOKEN` at the job `env` level as `${{ secrets.CODACY_PROJECT_TOKEN }}` and update the Codacy step to use `if: ${{ env.CODACY_PROJECT_TOKEN != '' }}` and `project-token: ${{ env.CODACY_PROJECT_TOKEN }}`, removing the redundant step-level `env`.

### Testing
- Validated the updated workflow parses as YAML using PyYAML via a small `python` script, and the parse succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7e0ceb024832eabd4cc6bba9194b9)