### PR TITLE
Fix SonarQube workflow secret usage in Codacy condition

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -51,13 +53,11 @@ jobs:
           PY
 
       - name: Run codacy-coverage-reporter
-        if: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
+        if: ${{ env.CODACY_PROJECT_TOKEN != '' }}
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
         with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          project-token: ${{ env.CODACY_PROJECT_TOKEN }}
           coverage-reports: "coverage.xml"
-        env:
-          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
       - name: SonarQube scan
         uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4


### PR DESCRIPTION
### Motivation
- GitHub Actions disallows using `secrets` directly inside a step `if` expression, which caused the SonarQube workflow to fail validation.

### Description
- Define `CODACY_PROJECT_TOKEN` at the job `env` using `secrets`, change the Codacy step condition to `if: ${{ env.CODACY_PROJECT_TOKEN != '' }}`, update the action `project-token` input to `env.CODACY_PROJECT_TOKEN`, and remove the redundant step-level `env` block in `.github/workflows/sonarqube.yml`.

### Testing
- Attempted to run `actionlint .github/workflows/sonarqube.yml` but the `actionlint` binary was not installed so the automated workflow lint check was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ecea33ac832eb25a8c124207612e)