### PR TITLE
tests: strengthen bridge unit tests, add run/main coverage, and fix derive_device_id case

### DIFF
--- a/tests/unit/test_bridge_unit.py
+++ b/tests/unit/test_bridge_unit.py
@@ -118,6 +118,7 @@ class BridgeUnitTests(unittest.TestCase):
         )
         self.assertEqual(self.bridge.derive_device_id("/tenant/devices/cam-07/video"), "cam-07")
         self.assertEqual(self.bridge.derive_device_id("orphan-topic"), "orphan-topic")
+        self.assertEqual(self.bridge.derive_device_id("/"), "unknown")
         self.assertEqual(self.bridge.pick_key("/tenant/devices/cam-07/video"), b"cam-07")
 
     def test_build_event_sensor_and_gps_and_media(self):
@@ -167,7 +168,9 @@ class BridgeUnitTests(unittest.TestCase):
         self.assertEqual(client.subscriptions, [])
 
     def test_on_message_sends_and_registers_callbacks(self):
-        fake_producer = _FakeKafkaProducer()
+        future = Mock()
+        fake_producer = Mock()
+        fake_producer.send.return_value = future
         msg = types.SimpleNamespace(
             topic="tenant/devices/sensor-1/sensor",
             payload=b'{"value": 5}',
@@ -178,9 +181,40 @@ class BridgeUnitTests(unittest.TestCase):
         with patch.object(self.bridge, "producer", fake_producer):
             self.bridge.on_message(None, None, msg)
 
-        self.assertEqual(len(fake_producer.sent), 1)
-        sent_topic, _key, _value = fake_producer.sent[0]
+        fake_producer.send.assert_called_once()
+        sent_topic = fake_producer.send.call_args.args[0]
         self.assertEqual(sent_topic, "raw.sensor")
+        future.add_callback.assert_called_once_with(self.bridge.on_send_success)
+        future.add_errback.assert_called_once_with(self.bridge.on_send_error)
+
+    def test_run_bridge_retries_after_oserror(self):
+        client = Mock()
+        client.connect.side_effect = [OSError("offline"), KeyboardInterrupt()]
+
+        with (
+            patch.object(self.bridge.time, "sleep") as mock_sleep,
+            pytest.raises(KeyboardInterrupt),
+        ):
+            self.bridge.run_bridge(client)
+
+        mock_sleep.assert_called_once_with(5)
+        client.loop_forever.assert_not_called()
+
+    def test_main_sets_credentials_and_runs_bridge(self):
+        client = _FakeClient()
+        with (
+            patch.object(self.bridge, "MQTT_USERNAME", "user"),
+            patch.object(self.bridge, "MQTT_PASSWORD", "pass"),
+            patch.object(self.bridge.mqtt_client, "Client", return_value=client),
+            patch.object(self.bridge, "run_bridge") as mock_run,
+        ):
+            self.bridge.main()
+
+        self.assertEqual(client.username, "user")
+        self.assertEqual(client.password, "pass")
+        self.assertEqual(client.on_connect, self.bridge.on_connect)
+        self.assertEqual(client.on_message, self.bridge.on_message)
+        mock_run.assert_called_once_with(client)
 
     def test_main_raises_when_mqtt_credentials_are_partial(self):
         with (


### PR DESCRIPTION
### Motivation

- Improve and broaden unit test coverage for the MQTT-Kafka bridge to validate producer future callback registration, retry behavior on `OSError` in `run_bridge`, and credential wiring in `main`.
- Make `derive_device_id` behavior explicit for root topic paths.

### Description

- Update `test_on_message_sends_and_registers_callbacks` to use a `Mock` producer and assert `send` was called and that the returned future had `add_callback` and `add_errback` called with `on_send_success` and `on_send_error` respectively.
- Add `test_run_bridge_retries_after_oserror` which simulates `client.connect` raising `OSError` then `KeyboardInterrupt` and asserts `time.sleep(5)` is called and `client.loop_forever` is not entered.
- Add `test_main_sets_credentials_and_runs_bridge` which patches `MQTT_USERNAME`/`MQTT_PASSWORD` and `mqtt_client.Client` and asserts the client credentials, callback wiring (`on_connect`/`on_message`), and that `run_bridge` is invoked.
- Add an assertion that `derive_device_id("/")` returns `"unknown"` in existing helper tests.

### Testing

- Ran the unit tests in `tests/unit/test_bridge_unit.py` (via `pytest`/`unittest`) and the suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f29d9558832ebeab20405208872d)