### PR TITLE
ci: force JavaScript GitHub Actions to run on Node 24

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   cross-platform-python-tests:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: '20 3 * * 1'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   analyze:
     name: Analyze (Python)

--- a/.github/workflows/compose-deployment-test.yml
+++ b/.github/workflows/compose-deployment-test.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   compose-smoke-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   renovate:
     runs-on: ubuntu-latest

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   sonarqube:
     name: SonarQube Scan


### PR DESCRIPTION
### Motivation
- GitHub announced Node.js 20 deprecation and Node.js 24 will become the default for Actions, which can break JavaScript-based actions that still run on Node 20. 
- The repository uses JavaScript actions (e.g., Dependabot/other ecosystem actions) that may be impacted by the change. 
- Opting workflows into Node.js 24 proactively avoids runtime failures when the runner default moves to Node.js 24.

### Description
- Added a top-level `env` entry `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to each workflow file under `.github/workflows/` to opt-in to Node 24 immediately. 
- Files modified: `.github/workflows/build-and-push-images.yml`, `.github/workflows/ci.yml`, `.github/workflows/codeql.yml`, `.github/workflows/compose-deployment-test.yml`, `.github/workflows/renovate.yml`, `.github/workflows/shellcheck.yml`, and `.github/workflows/sonarqube.yml`. 
- This is a minimal change that only injects the environment variable and does not alter job steps or runner selection.

### Testing
- Ran `rg` searches to locate relevant workflow entries and confirm updates, which succeeded. 
- Inspected diffs with `git diff -- .github/workflows/*.yml` to verify the inserted `env` blocks, which succeeded. 
- Confirmed repository status with `git status --short` and committed the change, which succeeded. 
- Attempted to run `yamllint .github/workflows/*.yml` but the tool is not installed in the environment, so linting could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f7e71090832eb9f36a39a8008e91)