### PR TITLE
ci: ignore local custom-flink-py image in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,8 @@ updates:
     labels:
       - "dependencies"
       - "dependabot"
+    ignore:
+      - dependency-name: "custom-flink-py"
 
   - package-ecosystem: "pip"
     directory: "/beam"


### PR DESCRIPTION
### Motivation
- Dependabot attempted to resolve the local `custom-flink-py` Docker image against Docker Hub and failed with `private_source_authentication_failure` during updates.

### Description
- Add an `ignore` rule for `dependency-name: "custom-flink-py"` to the `docker-compose` update block in ` .github/dependabot.yml` to prevent Dependabot from trying to update a local/custom image.
- Update is limited to the `docker-compose` ecosystem and does not affect other update blocks.

### Testing
- Ran a Python/PyYAML validation script to parse ` .github/dependabot.yml` and confirm valid YAML structure and presence of `updates`, which completed successfully (parsed 5 update blocks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7fb599948832eb70e40589bb871e3)