### PR TITLE
Fix YAML lint issues in GitHub workflows (bracket spacing & OSSAR indentation)

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,10 +1,10 @@
 name: Bandit
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
     - cron: '16 8 * * 5'
 

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -15,10 +15,10 @@ name: Codacy Security Scan
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
     - cron: '32 11 * * 6'
 

--- a/.github/workflows/ossar.yml
+++ b/.github/workflows/ossar.yml
@@ -2,10 +2,10 @@ name: OSSAR
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
     - cron: '44 17 * * 5'
 
@@ -23,16 +23,16 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
       # Run open source static analysis tools
-    - name: Run OSSAR
-      uses: github/ossar-action@v1
-      id: ossar
+      - name: Run OSSAR
+        uses: github/ossar-action@v1
+        id: ossar
 
       # Upload results to the Security tab
-    - name: Upload OSSAR results
-      uses: github/codeql-action/upload-sarif@v4
-      with:
-        sarif_file: ${{ steps.ossar.outputs.sarifFile }}
+      - name: Upload OSSAR results
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ steps.ossar.outputs.sarifFile }}

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -13,13 +13,13 @@ name: OSV-Scanner
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   merge_group:
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
     - cron: '33 22 * * 3'
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   # Require writing security events to upload SARIF file to security tab


### PR DESCRIPTION
### Motivation
- Fix `yamllint` errors about extra spaces inside bracketed inline arrays and a wrong indentation under `steps` so the workflow YAMLs are style-compliant while preserving their behavior.

### Description
- Replace `branches: [ "main" ]` with `branches: ["main"]` in `.github/workflows/osv-scanner.yml`, `.github/workflows/codacy.yml`, `.github/workflows/bandit.yml`, and `.github/workflows/ossar.yml`, and correct the `steps` list indentation in `.github/workflows/ossar.yml` so each step is properly nested under `steps:`.

### Testing
- Attempted to run `yamllint` against the updated files but the tool is not available in the environment (`yamllint: command not found`), so lint verification was not executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8087c8a94832e963ca96f2a45daf4)