### PR TITLE
Normalize SARIF run categories before upload in Codacy workflow

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -54,8 +54,25 @@ jobs:
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647
 
+      # Ensure each SARIF run has a distinct category so upload-sarif@v4 can ingest all runs.
+      - name: Normalize SARIF categories
+        run: |
+          jq '
+            if (.runs | length) > 1 then
+              .runs |= to_entries | map(
+                .value + {
+                  automationDetails: (
+                    (.value.automationDetails // {}) + { id: ("codacy-security-scan-" + (.key | tostring)) }
+                  )
+                }
+              )
+            else
+              .
+            end
+          ' results.sarif > results.normalized.sarif
+
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: results.sarif
+          sarif_file: results.normalized.sarif


### PR DESCRIPTION
### Motivation
- `github/codeql-action/upload-sarif@v4` rejects SARIF files that contain multiple runs with the same category, and Codacy can emit multi-run SARIF which caused uploads to fail.  

### Description
- Add a `Normalize SARIF categories` step to `.github/workflows/codacy.yml` that runs `jq` to assign a unique `automationDetails.id` of `codacy-security-scan-<index>` to each SARIF run when `.runs` contains more than one entry.  
- Switch the upload input for `github/codeql-action/upload-sarif@v4` from `results.sarif` to `results.normalized.sarif`.  
- Change is contained in the single workflow file ` .github/workflows/codacy.yml`.  

### Testing
- No full CI job was executed as part of this change.  
- Repository verification commands `git diff` and `nl -ba .github/workflows/codacy.yml` were run and confirmed the workflow file was updated and the upload step now targets `results.normalized.sarif`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d80af686a8832e91b7d0fd7f71d231)