### PR TITLE
Fix Codacy SARIF upload category collision

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -54,8 +54,30 @@ jobs:
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647
 
+      - name: Ensure unique SARIF categories per run
+        run: |
+          jq '
+            .runs |= to_entries | map(
+              .value + {
+                automationDetails: (
+                  (.value.automationDetails // {}) + {
+                    id: (
+                      "codacy/" +
+                      (
+                        (.value.tool.driver.name // "run")
+                        | ascii_downcase
+                        | gsub("[^a-z0-9._-]"; "-")
+                      ) +
+                      "-" + (.key | tostring)
+                    )
+                  }
+                )
+              }
+            )
+          ' results.sarif > results.normalized.sarif
+
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: results.sarif
+          sarif_file: results.normalized.sarif


### PR DESCRIPTION
### Motivation

- GitHub's `upload-sarif` now rejects multiple SARIF runs that share the same category, and Codacy can emit multiple runs in a single `results.sarif` which caused uploads to fail.

### Description

- Add a normalization step in the `Codacy` workflow (`.github/workflows/codacy.yml`) that rewrites each SARIF run's `automationDetails.id` using `jq` to produce unique IDs derived from the tool name and run index.
- Write the normalized output to `results.normalized.sarif` and change the upload step to send `results.normalized.sarif` to `github/codeql-action/upload-sarif@v4` instead of the raw `results.sarif`.
- The `jq` transform lowercases and sanitizes the tool name and prefixes with `codacy/` to ensure deterministic, unique category identifiers per run.

### Testing

- Confirmed the workflow file now contains the normalization step by inspecting `nl -ba .github/workflows/codacy.yml | sed -n '40,120p'`, and the command succeeded.
- Searched workflow files for SARIF upload occurrences with `rg -n "upload-sarif|sarif|codeql-action/analyze|category" .github/workflows` to verify the upload target was updated, and the search succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d80b4b778c832ead1aed0d0ef7cf61)