### PR TITLE
Fix jq precedence in Codacy SARIF normalization

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -59,13 +59,13 @@ jobs:
         run: |
           jq '
             if (.runs | length) > 1 then
-              .runs |= to_entries | map(
+              .runs |= (to_entries | map(
                 .value + {
                   automationDetails: (
                     (.value.automationDetails // {}) + { id: ("codacy-security-scan-" + (.key | tostring)) }
                   )
                 }
-              )
+              ))
             else
               .
             end


### PR DESCRIPTION
### Motivation
- Prevent a jq operator-precedence bug in the Codacy workflow that caused runtime failures like `Cannot index string with string "key"` and ensure each SARIF run receives a unique `automationDetails.id`.

### Description
- Update ` .github/workflows/codacy.yml` to wrap the `to_entries | map(...)` expression in parentheses so the assignment is ` .runs |= (to_entries | map(...))`, ensuring `map(...)` is applied to `.runs` entries rather than the entire document.

### Testing
- Ran the `jq` normalization locally on a representative SARIF sample using the same snippet and confirmed `jq` exited successfully and produced `automationDetails.id` values such as `codacy-security-scan-0` and `codacy-security-scan-1`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d80e52c5d0832ea223e0641f42bfd7)