### PR TITLE
Refactor unit-test context manager blocks

### DIFF
--- a/tests/unit/test_bridge_unit.py
+++ b/tests/unit/test_bridge_unit.py
@@ -200,13 +200,12 @@ class BridgeUnitTests(unittest.TestCase):
 
     def test_main_sets_credentials_and_runs_bridge(self):
         client = _FakeClient()
-        with patch.object(self.bridge, "MQTT_USERNAME", "user"), patch.object(
-            self.bridge, "MQTT_PASSWORD", "pass"
-        ), patch.object(
-            self.bridge.mqtt_client, "Client", return_value=client
-        ), patch.object(
-            self.bridge, "run_bridge"
-        ) as mock_run:
+        with (
+            patch.object(self.bridge, "MQTT_USERNAME", "user"),
+            patch.object(self.bridge, "MQTT_PASSWORD", "pass"),
+            patch.object(self.bridge.mqtt_client, "Client", return_value=client),
+            patch.object(self.bridge, "run_bridge") as mock_run,
+        ):
             self.bridge.main()
 
         self.assertEqual(client.username, "user")
@@ -216,11 +215,13 @@ class BridgeUnitTests(unittest.TestCase):
         mock_run.assert_called_once_with(client)
 
     def test_main_raises_when_mqtt_credentials_are_partial(self):
-        with patch.object(self.bridge, "MQTT_USERNAME", "user"), patch.object(
-            self.bridge, "MQTT_PASSWORD", None
-        ), pytest.raises(
-            ValueError,
-            match="MQTT_USERNAME and MQTT_PASSWORD must both be set when MQTT auth is enabled",
+        with (
+            patch.object(self.bridge, "MQTT_USERNAME", "user"),
+            patch.object(self.bridge, "MQTT_PASSWORD", None),
+            pytest.raises(
+                ValueError,
+                match="MQTT_USERNAME and MQTT_PASSWORD must both be set when MQTT auth is enabled",
+            ),
         ):
             self.bridge.main()
 

--- a/tests/unit/test_media_backfill_unit.py
+++ b/tests/unit/test_media_backfill_unit.py
@@ -154,9 +154,7 @@ class MediaBackfillUnitTests(unittest.TestCase):
             },
             clear=True,
         ):
-            with patch.object(
-                self.module.boto3, "client", return_value="s3-client"
-            ) as mock_client:
+            with patch.object(self.module.boto3, "client", return_value="s3-client") as mock_client:
                 with patch.object(
                     self.module, "KafkaProducer", return_value="producer"
                 ) as mock_prod:
@@ -189,14 +187,11 @@ class MediaBackfillUnitTests(unittest.TestCase):
             }
         ]
 
-        with patch.object(
-            self.module.argparse.ArgumentParser, "parse_args", return_value=args
-        ), patch.object(
-            self.module, "resolve_window", return_value=(start, end)
-        ), patch.object(
-            self.module, "get_kafka_producer", return_value=producer
-        ), patch.object(
-            self.module, "iter_objects_between", return_value=objects
+        with (
+            patch.object(self.module.argparse.ArgumentParser, "parse_args", return_value=args),
+            patch.object(self.module, "resolve_window", return_value=(start, end)),
+            patch.object(self.module, "get_kafka_producer", return_value=producer),
+            patch.object(self.module, "iter_objects_between", return_value=objects),
         ):
             output = io.StringIO()
             with redirect_stdout(output):


### PR DESCRIPTION
### Motivation
- Improve readability and formatting consistency of multi-context `with` blocks in unit tests without changing test behavior.

### Description
- Replace chained `with patch.object(...), patch.object(...), ...` constructs with parenthesized multi-context syntax using `with (` ... `):` in tests.
- Apply the change in `tests/unit/test_bridge_unit.py` for MQTT credential and bridge execution setup checks and in `tests/unit/test_media_backfill_unit.py` for boto3/Kafka patching and `main()` orchestration.
- Maintain existing assertions and test logic so no runtime behavior is altered.

### Testing
- Ran `pytest -q tests/unit/test_bridge_unit.py tests/unit/test_media_backfill_unit.py` and the suite passed with all tests succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d816f8ff1c832ea37a445d6e7bc9c2)