### PR TITLE
Lowercase GHCR repository owner in build-and-push workflow

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -58,7 +58,8 @@ jobs:
 
       - name: Build and push ${{ matrix.image_name }}
         run: |
-          IMAGE="ghcr.io/${{ github.repository_owner }}/dealiot-${{ matrix.image_name }}"
+          OWNER_LC="${GITHUB_REPOSITORY_OWNER,,}"
+          IMAGE="ghcr.io/${OWNER_LC}/dealiot-${{ matrix.image_name }}"
           TAGS=("--tag" "${IMAGE}:sha-${GITHUB_SHA}")
           if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
             TAGS+=("--tag" "${IMAGE}:latest")


### PR DESCRIPTION
### Motivation
- Prevent GHCR build failure when `GITHUB_REPOSITORY_OWNER` contains uppercase letters by ensuring the repository path used for image names is lowercase.

### Description
- Update `.github/workflows/build-and-push-images.yml` to compute `OWNER_LC="${GITHUB_REPOSITORY_OWNER,,}"` and use `IMAGE="ghcr.io/${OWNER_LC}/dealiot-${{ matrix.image_name }}"` so generated GHCR repository names are lowercase while preserving existing tag logic (`sha-*`, `latest` on `main`, and release tags).

### Testing
- Verified with a shell check `OWNER='Smartappli'; GITHUB_REPOSITORY_OWNER="$OWNER" bash -lc 'OWNER_LC="${GITHUB_REPOSITORY_OWNER,,}"; IMAGE="ghcr.io/${OWNER_LC}/dealiot-flink-pyflink"; echo "$IMAGE"'` which output `ghcr.io/smartappli/dealiot-flink-pyflink` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d817667424832ea586afbe596d737b)