### PR TITLE
Fix yamllint bracket spacing in OSV scanner workflow

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -13,13 +13,13 @@ name: OSV-Scanner
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   merge_group:
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
     - cron: '16 6 * * 4'
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   # Allow reusable workflow to read action metadata


### PR DESCRIPTION
### Motivation
- Fix `yamllint` `brackets` rule errors in ` .github/workflows/osv-scanner.yml` by normalizing inline array spacing for `branches` entries.

### Description
- Replace `[ "main" ]` with `["main"]` for the `pull_request`, `merge_group`, and `push` triggers in `.github/workflows/osv-scanner.yml`.

### Testing
- Attempted to run `yamllint .github/workflows/osv-scanner.yml` but it could not be executed in this environment because `yamllint` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d828d5cca0832e9ccc4d68cb9a0461)