### PR TITLE
Fix F999 syntax alerts in unit tests

### DIFF
--- a/tests/unit/test_bridge_unit.py
+++ b/tests/unit/test_bridge_unit.py
@@ -191,9 +191,8 @@ class BridgeUnitTests(unittest.TestCase):
         client = Mock()
         client.connect.side_effect = [OSError("offline"), KeyboardInterrupt()]
 
-        with (
-            patch.object(self.bridge.time, "sleep") as mock_sleep,
-            pytest.raises(KeyboardInterrupt),
+        with patch.object(self.bridge.time, "sleep") as mock_sleep, pytest.raises(
+            KeyboardInterrupt
         ):
             self.bridge.run_bridge(client)
 
@@ -202,12 +201,13 @@ class BridgeUnitTests(unittest.TestCase):
 
     def test_main_sets_credentials_and_runs_bridge(self):
         client = _FakeClient()
-        with (
-            patch.object(self.bridge, "MQTT_USERNAME", "user"),
-            patch.object(self.bridge, "MQTT_PASSWORD", "pass"),
-            patch.object(self.bridge.mqtt_client, "Client", return_value=client),
-            patch.object(self.bridge, "run_bridge") as mock_run,
-        ):
+        with patch.object(self.bridge, "MQTT_USERNAME", "user"), patch.object(
+            self.bridge, "MQTT_PASSWORD", "pass"
+        ), patch.object(
+            self.bridge.mqtt_client, "Client", return_value=client
+        ), patch.object(
+            self.bridge, "run_bridge"
+        ) as mock_run:
             self.bridge.main()
 
         self.assertEqual(client.username, "user")
@@ -217,13 +217,11 @@ class BridgeUnitTests(unittest.TestCase):
         mock_run.assert_called_once_with(client)
 
     def test_main_raises_when_mqtt_credentials_are_partial(self):
-        with (
-            patch.object(self.bridge, "MQTT_USERNAME", "user"),
-            patch.object(self.bridge, "MQTT_PASSWORD", None),
-            pytest.raises(
-                ValueError,
-                match="MQTT_USERNAME and MQTT_PASSWORD must both be set when MQTT auth is enabled",
-            ),
+        with patch.object(self.bridge, "MQTT_USERNAME", "user"), patch.object(
+            self.bridge, "MQTT_PASSWORD", None
+        ), pytest.raises(
+            ValueError,
+            match="MQTT_USERNAME and MQTT_PASSWORD must both be set when MQTT auth is enabled",
         ):
             self.bridge.main()
 

--- a/tests/unit/test_media_backfill_unit.py
+++ b/tests/unit/test_media_backfill_unit.py
@@ -144,20 +144,20 @@ class MediaBackfillUnitTests(unittest.TestCase):
 
     def test_get_s3_client_and_kafka_producer_use_environment(self):
         aws_key_material = "unit-test-key"
-        with (
-            patch.dict(
-                os.environ,
-                {
-                    "S3_ENDPOINT_URL": "http://s3.local",
-                    "AWS_ACCESS_KEY_ID": "k",
-                    "AWS_SECRET_ACCESS_KEY": aws_key_material,  # nosec B105
-                    "KAFKA_BOOTSTRAP_SERVERS": "k1:9092,k2:9092",
-                },
-                clear=True,
-            ),
-            patch.object(self.module.boto3, "client", return_value="s3-client") as mock_client,
-            patch.object(self.module, "KafkaProducer", return_value="producer") as mock_prod,
-        ):
+        with patch.dict(
+            os.environ,
+            {
+                "S3_ENDPOINT_URL": "http://s3.local",
+                "AWS_ACCESS_KEY_ID": "k",
+                "AWS_SECRET_ACCESS_KEY": aws_key_material,  # nosec B105
+                "KAFKA_BOOTSTRAP_SERVERS": "k1:9092,k2:9092",
+            },
+            clear=True,
+        ), patch.object(
+            self.module.boto3, "client", return_value="s3-client"
+        ) as mock_client, patch.object(
+            self.module, "KafkaProducer", return_value="producer"
+        ) as mock_prod:
             self.assertEqual(self.module.get_s3_client(), "s3-client")
             self.assertEqual(self.module.get_kafka_producer(), "producer")
 
@@ -187,11 +187,14 @@ class MediaBackfillUnitTests(unittest.TestCase):
             }
         ]
 
-        with (
-            patch.object(self.module.argparse.ArgumentParser, "parse_args", return_value=args),
-            patch.object(self.module, "resolve_window", return_value=(start, end)),
-            patch.object(self.module, "get_kafka_producer", return_value=producer),
-            patch.object(self.module, "iter_objects_between", return_value=objects),
+        with patch.object(
+            self.module.argparse.ArgumentParser, "parse_args", return_value=args
+        ), patch.object(
+            self.module, "resolve_window", return_value=(start, end)
+        ), patch.object(
+            self.module, "get_kafka_producer", return_value=producer
+        ), patch.object(
+            self.module, "iter_objects_between", return_value=objects
         ):
             output = io.StringIO()
             with redirect_stdout(output):


### PR DESCRIPTION
### Motivation

- Suppress `invalid syntax (F999)` warnings raised by static analyzers/older linters by avoiding parenthesized multi-context `with (...)` blocks in unit tests.

### Description

- Rewrote parenthesized multi-context `with (...)` blocks to comma-separated context managers in `tests/unit/test_bridge_unit.py` to avoid the problematic syntax while preserving semantics.
- Applied the same rewrite in `tests/unit/test_media_backfill_unit.py` for the two flagged `with` blocks, with no change to test logic.

### Testing

- Ran `python -m py_compile tests/unit/test_bridge_unit.py tests/unit/test_media_backfill_unit.py` which succeeded with no syntax errors.
- Ran `pytest -q tests/unit/test_bridge_unit.py tests/unit/test_media_backfill_unit.py` and all tests passed (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d82d564b50832eb7b1bbd7c1f5b966)