### PR TITLE
Apply ruff formatting to unit test context managers

### DIFF
--- a/tests/unit/test_bridge_unit.py
+++ b/tests/unit/test_bridge_unit.py
@@ -191,8 +191,9 @@ class BridgeUnitTests(unittest.TestCase):
         client = Mock()
         client.connect.side_effect = [OSError("offline"), KeyboardInterrupt()]
 
-        with patch.object(self.bridge.time, "sleep") as mock_sleep, pytest.raises(
-            KeyboardInterrupt
+        with (
+            patch.object(self.bridge.time, "sleep") as mock_sleep,
+            pytest.raises(KeyboardInterrupt),
         ):
             self.bridge.run_bridge(client)
 
@@ -201,13 +202,12 @@ class BridgeUnitTests(unittest.TestCase):
 
     def test_main_sets_credentials_and_runs_bridge(self):
         client = _FakeClient()
-        with patch.object(self.bridge, "MQTT_USERNAME", "user"), patch.object(
-            self.bridge, "MQTT_PASSWORD", "pass"
-        ), patch.object(
-            self.bridge.mqtt_client, "Client", return_value=client
-        ), patch.object(
-            self.bridge, "run_bridge"
-        ) as mock_run:
+        with (
+            patch.object(self.bridge, "MQTT_USERNAME", "user"),
+            patch.object(self.bridge, "MQTT_PASSWORD", "pass"),
+            patch.object(self.bridge.mqtt_client, "Client", return_value=client),
+            patch.object(self.bridge, "run_bridge") as mock_run,
+        ):
             self.bridge.main()
 
         self.assertEqual(client.username, "user")
@@ -217,11 +217,13 @@ class BridgeUnitTests(unittest.TestCase):
         mock_run.assert_called_once_with(client)
 
     def test_main_raises_when_mqtt_credentials_are_partial(self):
-        with patch.object(self.bridge, "MQTT_USERNAME", "user"), patch.object(
-            self.bridge, "MQTT_PASSWORD", None
-        ), pytest.raises(
-            ValueError,
-            match="MQTT_USERNAME and MQTT_PASSWORD must both be set when MQTT auth is enabled",
+        with (
+            patch.object(self.bridge, "MQTT_USERNAME", "user"),
+            patch.object(self.bridge, "MQTT_PASSWORD", None),
+            pytest.raises(
+                ValueError,
+                match="MQTT_USERNAME and MQTT_PASSWORD must both be set when MQTT auth is enabled",
+            ),
         ):
             self.bridge.main()
 

--- a/tests/unit/test_media_backfill_unit.py
+++ b/tests/unit/test_media_backfill_unit.py
@@ -144,20 +144,20 @@ class MediaBackfillUnitTests(unittest.TestCase):
 
     def test_get_s3_client_and_kafka_producer_use_environment(self):
         aws_key_material = "unit-test-key"
-        with patch.dict(
-            os.environ,
-            {
-                "S3_ENDPOINT_URL": "http://s3.local",
-                "AWS_ACCESS_KEY_ID": "k",
-                "AWS_SECRET_ACCESS_KEY": aws_key_material,  # nosec B105
-                "KAFKA_BOOTSTRAP_SERVERS": "k1:9092,k2:9092",
-            },
-            clear=True,
-        ), patch.object(
-            self.module.boto3, "client", return_value="s3-client"
-        ) as mock_client, patch.object(
-            self.module, "KafkaProducer", return_value="producer"
-        ) as mock_prod:
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "S3_ENDPOINT_URL": "http://s3.local",
+                    "AWS_ACCESS_KEY_ID": "k",
+                    "AWS_SECRET_ACCESS_KEY": aws_key_material,  # nosec B105
+                    "KAFKA_BOOTSTRAP_SERVERS": "k1:9092,k2:9092",
+                },
+                clear=True,
+            ),
+            patch.object(self.module.boto3, "client", return_value="s3-client") as mock_client,
+            patch.object(self.module, "KafkaProducer", return_value="producer") as mock_prod,
+        ):
             self.assertEqual(self.module.get_s3_client(), "s3-client")
             self.assertEqual(self.module.get_kafka_producer(), "producer")
 
@@ -187,14 +187,11 @@ class MediaBackfillUnitTests(unittest.TestCase):
             }
         ]
 
-        with patch.object(
-            self.module.argparse.ArgumentParser, "parse_args", return_value=args
-        ), patch.object(
-            self.module, "resolve_window", return_value=(start, end)
-        ), patch.object(
-            self.module, "get_kafka_producer", return_value=producer
-        ), patch.object(
-            self.module, "iter_objects_between", return_value=objects
+        with (
+            patch.object(self.module.argparse.ArgumentParser, "parse_args", return_value=args),
+            patch.object(self.module, "resolve_window", return_value=(start, end)),
+            patch.object(self.module, "get_kafka_producer", return_value=producer),
+            patch.object(self.module, "iter_objects_between", return_value=objects),
         ):
             output = io.StringIO()
             with redirect_stdout(output):


### PR DESCRIPTION
### Motivation
- CI reported `ruff-format` modified files due to multi-context `with` statements not matching Ruff's preferred style, so tests needed formatting fixes to satisfy linters. 

### Description
- Applied Ruff-driven formatting-only changes to `tests/unit/test_bridge_unit.py` and `tests/unit/test_media_backfill_unit.py`. 
- Converted several multi-context `with` statements into parenthesized grouped context managers as produced by `ruff format`. 
- No behavioral changes were made to test logic or assertions. 

### Testing
- Ran `ruff format` on the two modified files which reformatted them successfully. 
- Ran `ruff check .` which completed successfully with no lint errors. 
- Ran `mypy .` which completed successfully with no type issues. 
- Attempted `pre-commit run --all-files` in the container but it failed due to `pre-commit` not being available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d82e7a5874832e9f1a793106176f02)