### PR TITLE
Improve MQTT→Kafka bridge error logging and add QA note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,18 @@ secrets/seaweedfs_s3_secret_key.txt
 secrets/seaweedfs_s3_access_key.txt
 secrets/patroni_repl_password.txt
 secrets/patroni_rewind_password.txt
+
+## 8. Quality checks and bug-fix workflow
+
+Before committing changes, run the local automated checks:
+
+```bash
+pytest -q
+```
+
+Recent reliability hardening:
+
+- The MQTT→Kafka bridge now logs asynchronous Kafka producer failures with the actual exception details, which makes transient broker/network issues diagnosable during operations.
 secrets/pgadmin_default_password.txt
 secrets/pgbouncer_ro_userlist.txt
 secrets/pgbouncer_rw_userlist.txt

--- a/mqtt-kafka-bridge/bridge.py
+++ b/mqtt-kafka-bridge/bridge.py
@@ -90,8 +90,8 @@ def on_send_success(record_metadata) -> None:
     )
 
 
-def on_send_error(_exc: KafkaError) -> None:
-    LOGGER.exception("Kafka send failed")
+def on_send_error(exc: KafkaError) -> None:
+    LOGGER.error("Kafka send failed: %s", exc)
 
 
 producer = KafkaProducer(


### PR DESCRIPTION
### Motivation
- Improve observability for asynchronous Kafka send failures from the MQTT→Kafka bridge and document the local QA check developers should run before committing changes.

### Description
- Change `on_send_error` in `mqtt-kafka-bridge/bridge.py` to accept the `exc` parameter and log the actual exception via `LOGGER.error("Kafka send failed: %s", exc)` instead of emitting a generic message.
- Add a `Quality checks and bug-fix workflow` section to `README.md` that documents the local verification command `pytest -q` and notes the bridge reliability hardening.

### Testing
- Ran `pytest -q` with the updated codebase and all tests passed (`34 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4ae6859a8832e9d93d07dddd7e24a)