### PR TITLE
Potential fix for code scanning alert no. 622: Clear-text logging of sensitive information

### DIFF
--- a/mqtt-kafka-bridge/bridge.py
+++ b/mqtt-kafka-bridge/bridge.py
@@ -283,10 +283,8 @@ def route_event(msg, kafka_topic: str, event: dict[str, Any]) -> tuple[str, dict
         return kafka_topic, event
 
     LOGGER.warning(
-        "Routing invalid MQTT event to DLQ intended_topic=%s mqtt_topic=%s errors=%s",
-        kafka_topic,
-        msg.topic,
-        errors,
+        "Routing invalid MQTT event to DLQ (details redacted) error_count=%d",
+        len(errors),
     )
     return DLQ_TOPIC, build_dlq_event(
         source="mqtt-bridge",


### PR DESCRIPTION
Potential fix for [https://github.com/Smartappli/DEALIoT/security/code-scanning/622](https://github.com/Smartappli/DEALIoT/security/code-scanning/622)

Best fix: **stop logging tainted/dynamic topic values in clear text** and replace them with non-sensitive metadata.  
In `mqtt-kafka-bridge/bridge.py`, update the warning in `route_event` (around lines 285–290) to remove `%s` placeholders for `kafka_topic` and `msg.topic`. Keep useful observability by logging safe aggregate information such as error count. This preserves behavior (routing to DLQ is unchanged) while eliminating sensitive clear-text logging and addressing all four alert variants at the same sink location.

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
